### PR TITLE
Check for active Subscriptions

### DIFF
--- a/tests/data/xml/SampleServiceDeliveryWithInvalidPublisher.xml
+++ b/tests/data/xml/SampleServiceDeliveryWithInvalidPublisher.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Siri xmlns="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0">
+	<ServiceDelivery>
+		<ResponseTimestamp>2024-10-25T01:00:14Z</ResponseTimestamp>
+		<ProducerRef>ANY-UNKNOWN-PUBLISHER</ProducerRef>
+		<ResponseMessageIdentifier>jpk8XMJ5R9ABlisp3XjVr</ResponseMessageIdentifier>
+		<Status>true</Status>
+		<MoreData>false</MoreData>
+		<SituationExchangeDelivery version="2.0">
+			<ResponseTimestamp>2024-10-25T01:00:14Z</ResponseTimestamp>
+			<SubscriberRef>TEST</SubscriberRef>
+			<SubscriptionRef>1</SubscriptionRef>
+			<Situations>
+				<PtSituationElement>
+					<CreationTime>2024-06-10T09:22:17Z</CreationTime>
+					<CountryRef>de</CountryRef>
+					<ParticipantRef>TEST-PUBLISHER</ParticipantRef>
+					<SituationNumber>ef478576-d1a8-527e-8820-5164ca986128</SituationNumber>
+					<Version>1</Version>
+					<Source>
+						<CountryRef>de</CountryRef>
+						<SourceType>directReport</SourceType>
+						<Name>EMS</Name>
+						<ExternalCode>EMS</ExternalCode>
+					</Source>
+					<VersionedAtTime>2024-06-10T09:22:47Z</VersionedAtTime>
+					<Progress>published</Progress>
+					<ValidityPeriod>
+						<StartTime>2024-06-10T02:00:00Z</StartTime>
+						<EndTime>2500-12-31T00:00:00Z</EndTime>
+					</ValidityPeriod>
+					<PublicationWindow>
+						<StartTime>2024-06-10T02:00:00Z</StartTime>
+						<EndTime>2500-12-31T00:00:00Z</EndTime>
+					</PublicationWindow>
+					<AlertCause>constructionWork</AlertCause>
+					<Severity>normal</Severity>
+					<Priority>2</Priority>
+					<Audience>public</Audience>
+					<ScopeType>stopPlace</ScopeType>
+					<Planned>true</Planned>
+					<Language>DE</Language>
+					<Summary xml:lang="DE">Vogesenstrasse verschoben</Summary>
+					<Description xml:lang="DE">Vogesenstrasse verschoben
+                Linie 62
+                Grund: Bauarbeiten</Description>
+					<Detail xml:lang="DE">Die Haltestelle Vogesenstrasse ist verschoben.
+                Betroffen ist die Linie 62.
+                Der Grund dafür sind Bauarbeiten.
+                Die Dauer der Einschränkung ist unbestimmt.
+                &lt;br&gt;
+                Die Ersatzhaltestelle befindet sich bei der Ersatzhaltestelle der Tramlinie 11.
+                Bitte beachten Sie die Informationstafeln auf der Haltestelle</Detail>
+					<Affects>
+						<StopPlaces>
+							<AffectedStopPlace>
+								<StopPlaceRef>8588794</StopPlaceRef>
+								<PlaceName>Vogesenstrasse</PlaceName>
+							</AffectedStopPlace>
+						</StopPlaces>
+					</Affects>
+					<Consequences>
+						<Consequence>
+							<Condition>unknown</Condition>
+							<Severity>normal</Severity>
+							<Affects>
+								<StopPlaces>
+									<AffectedStopPlace>
+										<StopPlaceRef>8588794</StopPlaceRef>
+										<Lines>
+											<AffectedLine>
+												<AffectedOperator>
+													<OperatorRef>37</OperatorRef>
+												</AffectedOperator>
+												<LineRef>85:37:62</LineRef>
+												<PublishedLineName>62</PublishedLineName>
+											</AffectedLine>
+										</Lines>
+									</AffectedStopPlace>
+								</StopPlaces>
+							</Affects>
+						</Consequence>
+					</Consequences>
+					<PublishingActions>
+						<PublishingAction>
+							<PublishAtScope>
+								<ScopeType>stopPlace</ScopeType>
+								<Affects>
+									<StopPlaces>
+										<AffectedStopPlace>
+											<StopPlaceRef>8588794</StopPlaceRef>
+											<Lines>
+												<AffectedLine>
+													<AffectedOperator>
+														<OperatorRef>37</OperatorRef>
+													</AffectedOperator>
+													<LineRef>85:37:62</LineRef>
+													<PublishedLineName>62</PublishedLineName>
+												</AffectedLine>
+											</Lines>
+										</AffectedStopPlace>
+									</StopPlaces>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<ActionRef>ems-7456-0</ActionRef>
+								<RecordedAtTime>2024-06-10T09:22:47Z</RecordedAtTime>
+								<OwnerRef>Basler Verkehrs-Betriebe (BVB)</OwnerRef>
+								<Perspective>general</Perspective>
+								<Perspective>stopPoint</Perspective>
+								<Perspective>vehicleJourney</Perspective>
+								<TextualContent>
+									<TextualContentSize>M</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">Vogesenstrasse verschoben</SummaryText>
+									</SummaryContent>
+									<ReasonContent>
+										<ReasonText xml:lang="DE">Bauarbeiten</ReasonText>
+									</ReasonContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Vogesenstrasse verschoben
+                    Linie 62
+                    Grund: Bauarbeiten</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+					</PublishingActions>
+				</PtSituationElement>
+			</Situations>
+		</SituationExchangeDelivery>
+	</ServiceDelivery>
+</Siri>

--- a/tests/test_subscriber_endpoint.py
+++ b/tests/test_subscriber_endpoint.py
@@ -4,6 +4,7 @@ import unittest.mock
 
 from fastapi.testclient import TestClient
 
+from vdv736.model import Subscription
 from vdv736.subscriber import SubscriberEndpoint
 from vdv736.response import xml2siri_response
 
@@ -13,6 +14,14 @@ class SubscriberEndpoint_Test(unittest.TestCase):
     def setUpClass(cls):
         cls.endpoint = SubscriberEndpoint('TEST')
 
+        # setup a virtual subscription, otherwise the subscriber will fail
+        # see #21 for details
+        virtual_subscription = Subscription()
+        virtual_subscription.remote_service_participant_ref = 'TEST-PUBLISHER'
+
+        cls.endpoint._local_node_database.add_subscription('1', virtual_subscription)
+
+        # create test client
         cls.client = TestClient(cls.endpoint.create_endpoint(
             'TEST', 
             '/vdv736'
@@ -48,6 +57,13 @@ class SubscriberEndpoint_Test(unittest.TestCase):
 
         self.endpoint.set_callbacks(None)
 
+    def test_SampleServiceDeliveryWithInvalidPublisher(self):
+        xml_filename = os.path.join(os.path.dirname(__file__), 'data/xml/SampleServiceDeliveryWithInvalidPublisher.xml')
+        with open(xml_filename, 'r') as xml_file:
+            response = self.client.post('/vdv736', content=xml_file.read())
+
+            self.assertEqual(401, response.status_code)
+    
     def test_InvalidXmlData(self):
         xml_filename = os.path.join(os.path.dirname(__file__), 'data/xml/InvalidXmlData.xml')
         with open(xml_filename, 'r') as xml_file:

--- a/vdv736/subscriber.py
+++ b/vdv736/subscriber.py
@@ -312,6 +312,18 @@ class SubscriberEndpoint():
         try:
             delivery = xml2siri_delivery(await req.body())
 
+            # check for active subscriptions from the publisher who has sent the delivery
+            delivery_producer_ref = sirixml_get_value(delivery, 'Siri.ServiceDelivery.ProducerRef')
+            
+            subscription_at_producer_found = False
+            for _, subscription in self._local_node_database.get_subscriptions().items():
+                if subscription.remote_service_participant_ref == delivery_producer_ref:
+                    subscription_at_producer_found = True
+                    break
+
+            if not subscription_at_producer_found:
+                return Response(status_code=401)
+            
             # process service delivery ...
             for pts in sirixml_get_elements(delivery, 'Siri.ServiceDelivery.SituationExchangeDelivery.Situations.PtSituationElement'):
                 situation_id = sirixml_get_value(pts, 'SituationNumber')


### PR DESCRIPTION
A check for active subscriptions has been added to subscribers endpoint. This ensures, that nobody can simply send a malicious delivery to the subscriber if he knows the subscribers endpoint URL. All deliveries are validated against their `ProducerRef` and the currently active subscriptions.