### PR TITLE
Added official Support for Request/Response

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,10 @@
             "module": "unittest",
             "args": ["discover"],
             "console": "integratedTerminal",
-            "env": {"PYTHONPATH": "${workspaceRoot}"}
+            "env": {
+                "PYTHONPATH": "${workspaceRoot}",
+                "PYTHONWARNINGS": "ignore::DeprecationWarning"
+            }
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ from vdv736.delivery import SiriDelivery
 def on_delivery(delivery: SiriDelivery) -> None:
     print('Delivery callback called...')
 
-with Subscriber('PY_TEST_SUBSCRIBER', './participants.yaml') as subscriber:
+with Subscriber('PY_TEST_SUBSCRIBER', './participants.yaml', publish_subscribe=False) as subscriber:
     
     # run a direct request on the subscriber
     # the on_delivery callback is called immediately afterwards
@@ -85,6 +85,8 @@ with Subscriber('PY_TEST_SUBSCRIBER', './participants.yaml') as subscriber:
     while True:
         pass
 ```
+
+Please note the keyword argument `publish_subscribe` set to `False` here in order to use request/response pattern.
 
 See sample scripts in the [demo](/demo) folder.
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,12 @@ def on_delivery(delivery: SiriDelivery) -> None:
     print('Delivery callback called...')
 
 with Subscriber('PY_TEST_SUBSCRIBER', './participants.yaml') as subscriber:
+    
+    # run a direct request on the subscriber
+    # the on_delivery callback is called immediately afterwards
     subscriber.request('PY_TEST_PUBLISHER')
 
+    # alternatively you can process every single situation using the method get_situations() and a for loop
     for situation_id, situation in subscriber.get_situations().items():
         pass # or to whatever you want to do ...
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,22 @@ with Subscriber('PY_TEST_SUBSCRIBER', './participants.yaml', publish_subscribe=F
 
 Please note the keyword argument `publish_subscribe` set to `False` here in order to use request/response pattern.
 
-See sample scripts in the [demo](/demo) folder.
+According to VDV736, all request must be performed using request method `POST`. However there're some data platforms providing ([OpenTransportData Swiss](https://opentransportdata.swiss/de/cookbook/siri-sx/)) SIRI-SX like data using the `GET` method. You can perform GET requests with custom headers using the following snippet:
+
+```python
+hdr = {
+    'Authorization': '[YourAccessToken]'
+}
+
+subscriber.request('PY_TEST_PUBLISHER', './participants.yaml', publish_subscribe=False, method='GET', headers=hdr)
+
+for situation_id, situation in subscriber.get_situations().items():
+    pass
+```
+
+_Please be aware, that `GET` requests are not supported officially!_
+
+See sample other scripts in the [demo](/demo) folder.
 
 ## License
 This project is licensed under the Apache License. See [LICENSE.md](LICENSE.md) for more information.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,20 @@ requires-python = ">=3.10"
 
 dynamic = ["version"]
 
+[project.optional-dependencies]
+test = [
+    "responses"
+]
+
+all = [
+    "pyvdv736[test]"
+]
+
 [tool.setuptools]
 packages = ["vdv736"]
 
 [tool.setuptools.package-dir]
-stopmonitor = "vdv736"
+pyvdv736 = "vdv736"
 
 [tool.setuptools_scm]
 write_to = "vdv736/version.py"

--- a/tests/data/yaml/participants_testconfig.yaml
+++ b/tests/data/yaml/participants_testconfig.yaml
@@ -1,0 +1,21 @@
+PY_TEST_SUBSCRIBER:
+  host: "127.0.0.1"
+  port: 9090
+  protocol: http
+  single_endpoint: null
+  status_endpoint: null
+  subscribe_endpoint: null
+  unsubscribe_endpoint: null
+  request_endpoint: null
+  delivery_endpoint: /delivery
+
+PY_TEST_PUBLISHER:
+  host: "127.0.0.1"
+  port: 9091
+  protocol: http
+  single_endpoint: null
+  status_endpoint: /status
+  subscribe_endpoint: /subscribe
+  unsubscribe_endpoint: /unsubscribe
+  request_endpoint: /request
+  delivery_endpoint: null

--- a/tests/test_subscriber_direct_request.py
+++ b/tests/test_subscriber_direct_request.py
@@ -4,6 +4,7 @@ import unittest
 import unittest.mock
 
 from vdv736.subscriber import Subscriber
+from vdv736.request import InvalidMethodError
 
 class SubscriberDirectRequest_Test(unittest.TestCase):
 
@@ -12,11 +13,19 @@ class SubscriberDirectRequest_Test(unittest.TestCase):
         with open(xml_filename, 'r') as xml_file:
             xml_content = xml_file.read()
         
-        self.responder = responses.RequestsMock()
+        self.responder = responses.RequestsMock(assert_all_requests_are_fired=False)
         self.responder.start()
 
         self.responder.add(
             responses.POST,
+            'http://127.0.0.1:9091/request',
+            body=xml_content,
+            content_type='application/xml',
+            status=200
+        )
+
+        self.responder.add(
+            responses.GET,
             'http://127.0.0.1:9091/request',
             body=xml_content,
             content_type='application/xml',
@@ -40,6 +49,20 @@ class SubscriberDirectRequest_Test(unittest.TestCase):
 
             self.assertEqual(True, subscriber.request('PY_TEST_PUBLISHER'))
             on_delivery_callback.assert_called()
+
+    def test_DirectRequestResponseUsingGET(self):
+
+        configfile = os.path.join(os.path.dirname(__file__), 'data/yaml/participants_testconfig.yaml')        
+        with Subscriber('PY_TEST_SUBSCRIBER', configfile, publish_subscribe=False) as subscriber:
+            self.assertEqual(True, subscriber.request('PY_TEST_PUBLISHER', method='GET'))
+            self.assertEqual(1, len(subscriber.get_situations()))
+
+    def test_DirectRequestResponseUsingInvalidMethod(self):
+
+        configfile = os.path.join(os.path.dirname(__file__), 'data/yaml/participants_testconfig.yaml')        
+        with Subscriber('PY_TEST_SUBSCRIBER', configfile, publish_subscribe=False) as subscriber:
+            with self.assertRaises(InvalidMethodError):
+                subscriber.request('PY_TEST_PUBLISHER', method='TESTMETHOD')
             
     def tearDown(self):
         self.responder.stop()

--- a/tests/test_subscriber_direct_request.py
+++ b/tests/test_subscriber_direct_request.py
@@ -1,0 +1,16 @@
+import os
+import unittest
+import unittest.mock
+
+class SubscriberDirectRequest_Test(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    def test_DirectRequestResponse(self):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        return super().tearDownClass()

--- a/tests/test_subscriber_direct_request.py
+++ b/tests/test_subscriber_direct_request.py
@@ -1,16 +1,69 @@
+import http.server
+import logging
 import os
+import socketserver
+import threading
 import unittest
 import unittest.mock
+
+from vdv736.subscriber import Subscriber
+
+
+class MockHttpPublisherHandler(http.server.SimpleHTTPRequestHandler):
+    def do_POST(self):
+        if self.path == '/request':
+            self.send_response(200)
+            self.send_header("Content-type", "application/xml")
+            self.end_headers()
+
+            xml_filename = os.path.join(os.path.dirname(__file__), 'data/xml/SampleServiceDelivery.xml')
+            with open(xml_filename, 'rb') as xml_file:
+                xml_content = xml_file.read()
+
+            self.wfile.write(xml_content)
+        else:
+            self.send_response(200)
+
+    def log_message(self, format, *args):
+        pass
+
 
 class SubscriberDirectRequest_Test(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        pass
+        cls.server = socketserver.TCPServer(("localhost", 9091), MockHttpPublisherHandler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever)
+        cls.thread.daemon = True
+        cls.thread.start()
+
+        logging.disable(logging.CRITICAL)
+
+        configfile = os.path.join(os.path.dirname(__file__), 'data/yaml/participants_testconfig.yaml')
+        cls.subscriber = Subscriber('PY_TEST_SUBSCRIBER', configfile)
+        cls.subscriber.__enter__()
 
     def test_DirectRequestResponse(self):
-        pass
+        self.assertEqual(True, self.subscriber.request('PY_TEST_PUBLISHER'))
+        self.assertEqual(1, len(self.subscriber.get_situations()))
+
+    def test_DirectRequestResponseWithCallback(self):
+        on_delivery_callback = unittest.mock.Mock()
+        
+        self.subscriber.set_callbacks(on_delivery_callback)
+
+        self.assertEqual(True, self.subscriber.request('PY_TEST_PUBLISHER'))
+        on_delivery_callback.assert_called()
+            
 
     @classmethod
     def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.thread.join()
+
+        logging.disable(logging.NOTSET)
+
+        cls.subscriber.__exit__(None, None, None)
+
         return super().tearDownClass()

--- a/tests/test_subscriber_direct_request.py
+++ b/tests/test_subscriber_direct_request.py
@@ -1,69 +1,48 @@
-import http.server
-import logging
 import os
-import socketserver
-import threading
+import responses
 import unittest
 import unittest.mock
 
 from vdv736.subscriber import Subscriber
 
-
-class MockHttpPublisherHandler(http.server.SimpleHTTPRequestHandler):
-    def do_POST(self):
-        if self.path == '/request':
-            self.send_response(200)
-            self.send_header("Content-type", "application/xml")
-            self.end_headers()
-
-            xml_filename = os.path.join(os.path.dirname(__file__), 'data/xml/SampleServiceDelivery.xml')
-            with open(xml_filename, 'rb') as xml_file:
-                xml_content = xml_file.read()
-
-            self.wfile.write(xml_content)
-        else:
-            self.send_response(200)
-
-    def log_message(self, format, *args):
-        pass
-
-
 class SubscriberDirectRequest_Test(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.server = socketserver.TCPServer(("localhost", 9091), MockHttpPublisherHandler)
-        cls.thread = threading.Thread(target=cls.server.serve_forever)
-        cls.thread.daemon = True
-        cls.thread.start()
+    def setUp(self):
+        xml_filename = os.path.join(os.path.dirname(__file__), 'data/xml/SampleServiceDelivery.xml')
+        with open(xml_filename, 'r') as xml_file:
+            xml_content = xml_file.read()
+        
+        self.responder = responses.RequestsMock()
+        self.responder.start()
 
-        logging.disable(logging.CRITICAL)
-
-        configfile = os.path.join(os.path.dirname(__file__), 'data/yaml/participants_testconfig.yaml')
-        cls.subscriber = Subscriber('PY_TEST_SUBSCRIBER', configfile)
-        cls.subscriber.__enter__()
+        self.responder.add(
+            responses.POST,
+            'http://127.0.0.1:9091/request',
+            body=xml_content,
+            content_type='application/xml',
+            status=200
+        )
 
     def test_DirectRequestResponse(self):
-        self.assertEqual(True, self.subscriber.request('PY_TEST_PUBLISHER'))
-        self.assertEqual(1, len(self.subscriber.get_situations()))
+
+        configfile = os.path.join(os.path.dirname(__file__), 'data/yaml/participants_testconfig.yaml')        
+        with Subscriber('PY_TEST_SUBSCRIBER', configfile, publish_subscribe=False) as subscriber:
+            self.assertEqual(True, subscriber.request('PY_TEST_PUBLISHER'))
+            self.assertEqual(1, len(subscriber.get_situations()))
 
     def test_DirectRequestResponseWithCallback(self):
+  
         on_delivery_callback = unittest.mock.Mock()
         
-        self.subscriber.set_callbacks(on_delivery_callback)
+        configfile = os.path.join(os.path.dirname(__file__), 'data/yaml/participants_testconfig.yaml')
+        with Subscriber('PY_TEST_SUBSCRIBER', configfile, publish_subscribe=False) as subscriber:
+            subscriber.set_callbacks(on_delivery_callback)
 
-        self.assertEqual(True, self.subscriber.request('PY_TEST_PUBLISHER'))
-        on_delivery_callback.assert_called()
+            self.assertEqual(True, subscriber.request('PY_TEST_PUBLISHER'))
+            on_delivery_callback.assert_called()
             
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.server.shutdown()
-        cls.server.server_close()
-        cls.thread.join()
-
-        logging.disable(logging.NOTSET)
-
-        cls.subscriber.__exit__(None, None, None)
+    def tearDown(self):
+        self.responder.stop()
+        self.responder.reset()
 
         return super().tearDownClass()

--- a/vdv736/publisher.py
+++ b/vdv736/publisher.py
@@ -157,7 +157,7 @@ class Publisher():
             
             if isinstance(siri_delivery, SituationExchangeDelivery):
                 delivery_endpoint = self._participant_config.participants[subscription.subscriber]['single_endpoint'] if self._participant_config.participants[subscription.subscriber]['single_endpoint'] is not None else self._participant_config.participants[subscription.subscriber]['delivery_endpoint']
-                endpoint = f"{subscription_protocol}://{subscription_host}:{subscription_port}/{delivery_endpoint}"
+                endpoint = f"{subscription_protocol}://{subscription_host}:{subscription_port}{delivery_endpoint}"
 
             headers = {
                 "Content-Type": "application/xml"

--- a/vdv736/request.py
+++ b/vdv736/request.py
@@ -10,6 +10,9 @@ from .isotime import interval
 from .model import Subscription
 
 
+class InvalidMethodError(Exception):
+    pass
+
 class SiriRequest(ABC):
 
     def __init__(self):

--- a/vdv736/subscriber.py
+++ b/vdv736/subscriber.py
@@ -200,7 +200,7 @@ class Subscriber():
             # process service delivery ...
             for pts in sirixml_get_elements(delivery, 'Siri.ServiceDelivery.SituationExchangeDelivery.Situations.PtSituationElement'):
                 situation_id = sirixml_get_value(pts, 'SituationNumber')
-                self._local_node_database.add_situation(situation_id, pts)
+                self._local_node_database.add_or_update_situation(situation_id, pts)
 
             return True
         else:

--- a/vdv736/subscriber.py
+++ b/vdv736/subscriber.py
@@ -203,14 +203,14 @@ class Subscriber():
         else:
             self._logger.error(f"Failed to terminate subscription {subscription.id} @ {subscription.remote_service_participant_ref} as {subscription.subscriber}")
             
-    def request(self, publisher_ref: str, method: str = 'POST') -> bool:
+    def request(self, publisher_ref: str, method: str = 'POST', headers: dict = dict()) -> bool:
 
         if self._pubsub:
             raise RuntimeError("Direct requests are only available in request/response mode!")
 
         # generate SituationExchangeRequest
         request = SituationExchangeRequest(self._service_participant_ref)
-        delivery = self._send_direct_request(publisher_ref, request, method)
+        delivery = self._send_direct_request(publisher_ref, request, method, headers)
 
         if delivery is not None:
             # check whether on_delivery callback is used ...
@@ -274,7 +274,7 @@ class Subscriber():
             self._logger.error(ex)
             return None
         
-    def _send_direct_request(self, publisher_ref: str, siri_request: SiriRequest, method: str) -> SituationExchangeDelivery|None:
+    def _send_direct_request(self, publisher_ref: str, siri_request: SiriRequest, method: str, headers: dict = dict()) -> SituationExchangeDelivery|None:
         try:
             subscription_host = self._participant_config.participants[publisher_ref]['host']
             subscription_port = self._participant_config.participants[publisher_ref]['port']
@@ -284,14 +284,17 @@ class Subscriber():
                 request_endpoint = self._participant_config.participants[publisher_ref]['single_endpoint'] if self._participant_config.participants[publisher_ref]['single_endpoint'] is not None else self._participant_config.participants[publisher_ref]['request_endpoint']
                 endpoint = f"{subscription_protocol}://{subscription_host}:{subscription_port}{request_endpoint}"
             
-            headers = {
+            siri_headers = {
                 "Content-Type": "application/xml"
             }
+
+            if len(headers) > 0:
+                siri_headers = siri_headers | headers
             
             if method.lower() == 'post':
-                response_xml = requests.post(endpoint, headers=headers, data=siri_request.xml())
+                response_xml = requests.post(endpoint, headers=siri_headers, data=siri_request.xml())
             elif method.lower() == 'get':
-                response_xml = requests.get(endpoint, headers=headers)
+                response_xml = requests.get(endpoint, headers=siri_headers)
             else:
                 raise InvalidMethodError(f"Invalid request method {method}!")
             

--- a/vdv736/subscriber.py
+++ b/vdv736/subscriber.py
@@ -13,6 +13,7 @@ from .delivery import SituationExchangeDelivery
 from .model import PublicTransportSituation
 from .model import Subscription
 from .participantconfig import ParticipantConfig
+from .request import InvalidMethodError
 from .request import SiriRequest
 from .request import CheckStatusRequest
 from .request import SituationExchangeSubscriptionRequest
@@ -202,14 +203,14 @@ class Subscriber():
         else:
             self._logger.error(f"Failed to terminate subscription {subscription.id} @ {subscription.remote_service_participant_ref} as {subscription.subscriber}")
             
-    def request(self, publisher_ref: str) -> bool:
+    def request(self, publisher_ref: str, method: str = 'POST') -> bool:
 
         if self._pubsub:
             raise RuntimeError("Direct requests are only available in request/response mode!")
 
         # generate SituationExchangeRequest
         request = SituationExchangeRequest(self._service_participant_ref)
-        delivery = self._send_direct_request(publisher_ref, request)
+        delivery = self._send_direct_request(publisher_ref, request, method)
 
         if delivery is not None:
             # check whether on_delivery callback is used ...
@@ -273,7 +274,7 @@ class Subscriber():
             self._logger.error(ex)
             return None
         
-    def _send_direct_request(self, publisher_ref: str, siri_request: SiriRequest) -> SituationExchangeDelivery|None:
+    def _send_direct_request(self, publisher_ref: str, siri_request: SiriRequest, method: str) -> SituationExchangeDelivery|None:
         try:
             subscription_host = self._participant_config.participants[publisher_ref]['host']
             subscription_port = self._participant_config.participants[publisher_ref]['port']
@@ -287,12 +288,24 @@ class Subscriber():
                 "Content-Type": "application/xml"
             }
             
-            response_xml = requests.post(endpoint, headers=headers, data=siri_request.xml())
+            if method.lower() == 'post':
+                response_xml = requests.post(endpoint, headers=headers, data=siri_request.xml())
+            elif method.lower() == 'get':
+                response_xml = requests.get(endpoint, headers=headers)
+            else:
+                raise InvalidMethodError(f"Invalid request method {method}!")
+            
             delivery = xml2siri_delivery(response_xml.content)
 
             return delivery
         except Exception as ex:
-            self._logger.error(ex)
+
+            # re-throw occuring InvalidMethodError in this case
+            if isinstance(ex, InvalidMethodError):
+                raise ex
+            else:
+                self._logger.error(ex)
+
             return None
 
 

--- a/vdv736/subscriber.py
+++ b/vdv736/subscriber.py
@@ -253,13 +253,13 @@ class Subscriber():
         try:
             if isinstance(siri_request, CheckStatusRequest):
                 status_endpoint = subscription.single_endpoint if subscription.single_endpoint is not None else subscription.status_endpoint
-                endpoint = f"{subscription.protocol}://{subscription.host}:{subscription.port}/{status_endpoint}"
+                endpoint = f"{subscription.protocol}://{subscription.host}:{subscription.port}{status_endpoint}"
             elif isinstance(siri_request, SituationExchangeSubscriptionRequest):
                 subscribe_endpoint = subscription.single_endpoint if subscription.single_endpoint is not None else subscription.subscribe_endpoint
-                endpoint = f"{subscription.protocol}://{subscription.host}:{subscription.port}/{subscribe_endpoint}"
+                endpoint = f"{subscription.protocol}://{subscription.host}:{subscription.port}{subscribe_endpoint}"
             elif isinstance(siri_request, TerminateSubscriptionRequest):
                 unsubscribe_endpoint = subscription.single_endpoint if subscription.single_endpoint is not None else subscription.unsubscribe_endpoint
-                endpoint = f"{subscription.protocol}://{subscription.host}:{subscription.port}/{unsubscribe_endpoint}"
+                endpoint = f"{subscription.protocol}://{subscription.host}:{subscription.port}{unsubscribe_endpoint}"
             
             headers = {
                 "Content-Type": "application/xml"
@@ -281,7 +281,7 @@ class Subscriber():
             
             if isinstance(siri_request, SituationExchangeRequest):
                 request_endpoint = self._participant_config.participants[publisher_ref]['single_endpoint'] if self._participant_config.participants[publisher_ref]['single_endpoint'] is not None else self._participant_config.participants[publisher_ref]['request_endpoint']
-                endpoint = f"{subscription_protocol}://{subscription_host}:{subscription_port}/{request_endpoint}"
+                endpoint = f"{subscription_protocol}://{subscription_host}:{subscription_port}{request_endpoint}"
             
             headers = {
                 "Content-Type": "application/xml"

--- a/vdv736/subscriber.py
+++ b/vdv736/subscriber.py
@@ -35,13 +35,15 @@ from threading import Thread
 
 class Subscriber():
 
-    def __init__(self, participant_ref: str, participant_config_filename: str, local_ip_address: str = '0.0.0.0'):
+    def __init__(self, participant_ref: str, participant_config_filename: str, local_ip_address: str = '0.0.0.0', publish_subscribe: bool = True):
         self._service_participant_ref = participant_ref
         self._service_local_ip_address = local_ip_address
+        self._pubsub = publish_subscribe
 
         self._logger = logging.getLogger('uvicorn')
 
         self._local_node_database = local_node_database('vdv736.subscriber')
+        self._endpoint = None
 
         self._on_delivery = None
 
@@ -51,40 +53,48 @@ class Subscriber():
             self._logger.error(ex)
 
     def __enter__(self):
-        self._endpoint_thread = Thread(target=self._run_endpoint, args=(), daemon=True)
-        self._endpoint_thread.start()
 
-        time.sleep(0.01) # give the endpoint thread time for startup
-        self._logger.info(f"Subscriber running at {self._participant_config.participants[self._service_participant_ref]['host']}:{self._participant_config.participants[self._service_participant_ref]['port']}")
-        self._logger.info(f"Local node database at {self._local_node_database._filename}")
+        if self._pubsub:
+            self._endpoint_thread = Thread(target=self._run_endpoint, args=(), daemon=True)
+            self._endpoint_thread.start()
+
+            time.sleep(0.01) # give the endpoint thread time for startup
+            self._logger.info(f"Subscriber running at {self._participant_config.participants[self._service_participant_ref]['host']}:{self._participant_config.participants[self._service_participant_ref]['port']}")
+            self._logger.info(f"Local node database at {self._local_node_database._filename}")
 
         return self
 
     def __exit__(self, exception_type, exception_value, exception_traceback) -> None:
         
-        # terminate all subscriptions
-        for subscription_id, subscription in self._local_node_database.get_subscriptions().items():
-            self.unsubscribe(subscription_id)
+        if self._pubsub:
+            # terminate all subscriptions
+            for subscription_id, subscription in self._local_node_database.get_subscriptions().items():
+                self.unsubscribe(subscription_id)
 
-        # terminate endpoint and close local database
-        if self._endpoint is not None:
-            self._endpoint.terminate()
-        
-        if self._endpoint_thread is not None:
-            self._endpoint_thread.join(1)
+            # terminate endpoint and close local database
+            if self._endpoint is not None:
+                self._endpoint.terminate()
+            
+            if self._endpoint_thread is not None:
+                self._endpoint_thread.join(1)
 
+        # local node database has to be closed anyway, regardless of using pubsub mode
         if self._local_node_database is not None:
             self._local_node_database.close(True)
 
     def set_callbacks(self, on_delivery_callback: typing.Callable[[SiriDelivery], None]) -> None:
         self._on_delivery = on_delivery_callback
 
-        self._endpoint.set_callbacks(self._on_delivery)
+        if self._endpoint is not None:
+            self._endpoint.set_callbacks(self._on_delivery)
 
     def get_situations(self) -> dict[str, PublicTransportSituation]:
         return self._local_node_database.get_situations()
 
     def status(self, subscription_id=None) -> bool:
+        if not self._pubsub:
+            raise RuntimeError("Status requests are only available in publish/subscribe mode!")
+        
         if subscription_id is not None:
             return self._status(subscription_id)
         else:
@@ -123,6 +133,9 @@ class Subscriber():
 
     def subscribe(self, participant_ref: str) -> str|None:
 
+        if not self._pubsub:
+            raise RuntimeError("Subscriptions can only be initialized in publish/subscribe mode!")
+        
         subscription_id = str(uuid.uuid4())
         subscription_host = self._participant_config.participants[participant_ref]['host']
         subscription_port = self._participant_config.participants[participant_ref]['port']
@@ -157,6 +170,9 @@ class Subscriber():
         
     def unsubscribe(self, subscription_id: str) -> bool:
         
+        if not self._pubsub:
+            raise RuntimeError("Subscriptions can only be terminated in publish/subscribe mode!")
+        
         # take subscription instance from subscription stack
         subscription = self._local_node_database.get_subscriptions()[subscription_id]
 
@@ -188,15 +204,18 @@ class Subscriber():
             
     def request(self, publisher_ref: str) -> bool:
 
+        if self._pubsub:
+            raise RuntimeError("Direct requests are only available in request/response mode!")
+
         # generate SituationExchangeRequest
         request = SituationExchangeRequest(self._service_participant_ref)
         delivery = self._send_direct_request(publisher_ref, request)
 
-        # check whether on_delivery callback is used ...
-        if self._on_delivery is not None:
-            self._on_delivery(delivery)
-
         if delivery is not None:
+            # check whether on_delivery callback is used ...
+            if self._on_delivery is not None:
+                self._on_delivery(delivery)
+
             # process service delivery ...
             for pts in sirixml_get_elements(delivery, 'Siri.ServiceDelivery.SituationExchangeDelivery.Situations.PtSituationElement'):
                 situation_id = sirixml_get_value(pts, 'SituationNumber')

--- a/vdv736/subscriber.py
+++ b/vdv736/subscriber.py
@@ -43,6 +43,8 @@ class Subscriber():
 
         self._local_node_database = local_node_database('vdv736.subscriber')
 
+        self._on_delivery = None
+
         try:
             self._participant_config = ParticipantConfig(participant_config_filename)
         except Exception as ex:
@@ -75,7 +77,9 @@ class Subscriber():
             self._local_node_database.close(True)
 
     def set_callbacks(self, on_delivery_callback: typing.Callable[[SiriDelivery], None]) -> None:
-        self._endpoint.set_callbacks(on_delivery_callback)
+        self._on_delivery = on_delivery_callback
+
+        self._endpoint.set_callbacks(self._on_delivery)
 
     def get_situations(self) -> dict[str, PublicTransportSituation]:
         return self._local_node_database.get_situations()
@@ -188,6 +192,10 @@ class Subscriber():
         request = SituationExchangeRequest(self._service_participant_ref)
         delivery = self._send_direct_request(publisher_ref, request)
 
+        # check whether on_delivery callback is used ...
+        if self._on_delivery is not None:
+            self._on_delivery(delivery)
+
         if delivery is not None:
             # process service delivery ...
             for pts in sirixml_get_elements(delivery, 'Siri.ServiceDelivery.SituationExchangeDelivery.Situations.PtSituationElement'):
@@ -199,7 +207,6 @@ class Subscriber():
             self._logger.error(f"Failed to request data from {publisher_ref}")
 
             return False
-
 
     def _run_endpoint(self) -> None:
         self._endpoint = SubscriberEndpoint(self._service_participant_ref)


### PR DESCRIPTION
- The callback on_delivery is now also called when using the request/response mode
- Situations can be updated now in request/response mode
- Request/response mode must be activated during construction of a subscriber using parameter `publish_subscribe` set to `False`; this way, the subscriber is not opening a endpoint server, as there's no need to be reachable over network
- Request/response mode can also be used with `GET` method and custom headers (experimental feature!)

- Generation of request URLs has been adapted and fixed, so that URLs are not generated with too much `/` chars anymore between base URL and endpoint