### PR TITLE
BugFix: Spelling Mistake in Datalog

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,15 @@
             "env": {"PYTHONPATH": "${workspaceRoot}/src"},
         },
         {
+            "name": "Debug: Subscriber",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "demo/demo_subscriber.py",
+            "console": "integratedTerminal",
+            "python": "${workspaceFolder}/venv/Scripts/python.exe",
+            "env": {"PYTHONPATH": "${workspaceRoot}/src"},
+        },
+        {
             "name": "Debug: Subscriber (P/S)",
             "type": "debugpy",
             "request": "launch",

--- a/src/vdv736/datalog.py
+++ b/src/vdv736/datalog.py
@@ -20,9 +20,9 @@ class Datalog:
             # proceed only if the datalogfile is not from today
             if not datalog_file.startswith(today):
                 datalog_timestamp = datalog_file.split('_')[0]
-                datalog_timestamp = datetime.strptime(datalog_timestamp, '%Y-%m-%d-%H.%M.%S-%f')
+                datalog_timestamp = datetime.datetime.strptime(datalog_timestamp, '%Y-%m-%d-%H.%M.%S-%f')
 
-                difference = (datetime.now() - datalog_timestamp).total_seconds()
+                difference = (datetime.datetime.now() - datalog_timestamp).total_seconds()
                 if difference > 60 * 60 * ttl_hours:
                     datalog_file = os.path.join(directory, datalog_file)
                     os.remove(datalog_file)
@@ -41,16 +41,20 @@ class Datalog:
                 try:
                     xml = tostring(fromstring(data), pretty_print=True)
                     datalog_file.write(xml)
-
-                    comment = "<!--\n"
-                    comment += "This message is create by datalog module - See https://gist.github.com/sebastianknopf/677d9ae9f213389e1c3f9aeb0b5e4055\n"
-                    comment += "\n"
-                    comment += "Request Meta Data:\n"
-                    comment += json.dumps(meta, indent=4) + "\n"
-                    comment += "-->"
-
-                    datalog_file.write(comment.encode('utf-8'))
+                    datalog_file.write(cls._comment(meta))
                 except Exception:
-                    pass
+                    datalog_file.write(data)
+                    datalog_file.write(cls._comment(meta))
                 finally:
                     datalog_file.close()
+
+    @classmethod
+    def _comment(cls, metadata: dict) -> str:
+        comment = "<!--\n"
+        comment += "This message is created by datalog module - See https://gist.github.com/sebastianknopf/677d9ae9f213389e1c3f9aeb0b5e4055\n"
+        comment += "\n"
+        comment += "Request Meta Data:\n"
+        comment += json.dumps(metadata, indent=4) + "\n"
+        comment += "-->"
+
+        return comment.encode('utf-8')

--- a/src/vdv736/subscriber.py
+++ b/src/vdv736/subscriber.py
@@ -334,7 +334,7 @@ class Subscriber():
                     'method': method.upper(),
                     'endpoint': endpoint,
                     'headers': headers
-                }, 'OUT', self._service_participant_ref, type(siri_request).__name__, 'Response')
+                }, self._service_participant_ref, 'OUT', type(siri_request).__name__, 'Response')
 
             delivery = xml2siri_delivery(response_xml.content)
 


### PR DESCRIPTION
Datalog calls had a small spelling mistake in former versions. This fix resolves the spelling mistake ensuring that every datalog filename matches the same pattern.