### PR TITLE
HotFix: Syntax Error in datalog Module

### DIFF
--- a/src/vdv736/datalog.py
+++ b/src/vdv736/datalog.py
@@ -20,9 +20,9 @@ class Datalog:
             # proceed only if the datalogfile is not from today
             if not datalog_file.startswith(today):
                 datalog_timestamp = datalog_file.split('_')[0]
-                datalog_timestamp = datetime.datetime.strptime(datalog_timestamp, '%Y-%m-%d-%H.%M.%S-%f')
+                datalog_timestamp = datetime.strptime(datalog_timestamp, '%Y-%m-%d-%H.%M.%S-%f')
 
-                difference = (datetime.datetime.now() - datalog_timestamp).total_seconds()
+                difference = (datetime.now() - datalog_timestamp).total_seconds()
                 if difference > 60 * 60 * ttl_hours:
                     datalog_file = os.path.join(directory, datalog_file)
                     os.remove(datalog_file)


### PR DESCRIPTION
A syntax error caused datalog module to fail when there were files from another day than yesterday. This PR fixes this problem.